### PR TITLE
[func]: Add HTML report support and project refs

### DIFF
--- a/Clarity.Dev/Clarity.Dev.Reports/Clarity.Dev.Reports.csproj
+++ b/Clarity.Dev/Clarity.Dev.Reports/Clarity.Dev.Reports.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\src\Clarity.Dev.NET.Core\Clarity.Dev.NET.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Clarity.Dev/Clarity.Dev.slnx
+++ b/Clarity.Dev/Clarity.Dev.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="Clarity.Dev.Reports/Clarity.Dev.Reports.csproj" Id="50b637b2-48f2-4f88-879b-52b7c5ffa0f5" />
     <Project Path="src/Clarity.Dev.CLI/Clarity.Dev.CLI.csproj" Id="dadfd712-1c14-41de-bdc9-2f8d1a360273" />
   </Folder>
   <Folder Name="/src/NET/">

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Clarity.Dev.CLI.csproj
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Clarity.Dev.CLI.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Clarity.Dev.Reports\Clarity.Dev.Reports.csproj" />
     <ProjectReference Include="..\Clarity.Dev.Analyzer\Clarity.Dev.NET.Analyzer.csproj" />
   </ItemGroup>
 

--- a/Clarity.Dev/src/Clarity.Dev.CLI/GlobalUsings.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/GlobalUsings.cs
@@ -4,5 +4,6 @@ global using Clarity.Dev.NET.Analyzer.Analysis;
 global using Clarity.Dev.NET.Analyzer.Core;
 global using Clarity.Dev.NET.Core.Models;
 global using Clarity.Dev.NET.Core.Models.Enums;
+global using Clarity.Dev.Reports;
 
 namespace Clarity.Dev.CLI;

--- a/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
@@ -41,6 +41,25 @@ internal static class SolutionAnalyzer
             Console.WriteLine("=======================================");
             Console.WriteLine();
 
+            if(OutputFormatTypesHelper.IsHtmlFormat(solutionAnalysisInput.OutputFormat) ||
+                OutputFormatTypesHelper.IsBothFormat(solutionAnalysisInput.OutputFormat))
+            {
+                HtmlReportGenerator htmlReportGenerator = new();
+                var htmlPath = solutionAnalysisInput.OutputPath.EndsWith(".html")
+                    ? solutionAnalysisInput.OutputPath
+                    : Path.ChangeExtension(solutionAnalysisInput.OutputPath, ".html");
+                var generatedHtmlPath = htmlReportGenerator.GenerateReport(result, htmlPath);
+
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                string htmlRelativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), generatedHtmlPath);
+                Console.WriteLine($"📄 HTML report generated at: {htmlRelativePath}");
+                Console.ResetColor();
+            }
+
+            Console.WriteLine();
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("🔧 Done!");
+            Console.ResetColor();
             return 0;
         }
         catch (Exception ex)

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/Enums/OutputFormatTypes.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/Enums/OutputFormatTypes.cs
@@ -18,4 +18,19 @@ public static class OutputFormatTypesHelper
     {
         return TryParse(value, out _);
     }
+
+    public static bool IsHtmlFormat(string value)
+    {
+        return TryParse(value, out var result) && result == OutputFormatTypes.html;
+    }
+
+    public static bool IsJsonFormat(string value)
+    {
+        return TryParse(value, out var result) && result == OutputFormatTypes.json;
+    }
+
+    public static bool IsBothFormat(string value)
+    {
+        return TryParse(value, out var result) && result == OutputFormatTypes.both;
+    }
 }


### PR DESCRIPTION
Integrate the Clarity.Dev.Reports project into the solution and CLI and add HTML report generation. Changes include:
- Add Reports project to the solution file and add project references (Reports -> NET.Core, CLI -> Reports).
- Add global using for Clarity.Dev.Reports in the CLI project.
- Implement HTML report generation in SolutionAnalyzer (handles .html extension, generates report, prints relative path to console).
- Extend OutputFormatTypes helper with IsHtmlFormat, IsJsonFormat, and IsBothFormat methods to drive output behavior.