### PR TITLE
[fix]: Reset console color; fix output format arg index

### DIFF
--- a/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
@@ -18,6 +18,7 @@ catch(Exception e)
     Console.ForegroundColor = ConsoleColor.Red;
     Console.WriteLine(e.Message);
     Console.WriteLine("Ending program with error.");
+    Console.ResetColor();
 }
 
 static string GetCliVersion()

--- a/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
@@ -88,7 +88,7 @@ internal static class SolutionAnalyzer
             }
             else if (SolutionCommandConstantsHelper.IsOutputOption(arguments[inputIndex]) && (inputIndex + 1) <= arguments.Length)
             {
-                if (!OutputFormatTypesHelper.IsValidOutputFormat(arguments[inputIndex]))
+                if (!OutputFormatTypesHelper.IsValidOutputFormat(arguments[inputIndex + 1]))
                 {
                     throw new Exception("Invalid Output Format!");
                 }


### PR DESCRIPTION
Restore console color after printing exceptions by calling Console.ResetColor() in the catch block. 
Fix argument validation in SolutionAnalyzer to check arguments[inputIndex + 1] for the output format (previously checked the wrong index), preventing incorrect "Invalid Output Format" errors.

### Dev Test Evidence (Positive Test)
<img width="1324" height="424" alt="image" src="https://github.com/user-attachments/assets/2b67c963-0cd8-4e47-8b70-874730b62ac6" />
<img width="1652" height="854" alt="image" src="https://github.com/user-attachments/assets/a6a2ef84-0bc5-492b-aeb8-9e1e0515cc9d" />
<img width="1207" height="862" alt="image" src="https://github.com/user-attachments/assets/6df3e5c2-bf05-445b-a148-70fa66659205" />

### Dev Test Evidence (Negative Test)
<img width="1326" height="505" alt="image" src="https://github.com/user-attachments/assets/0fc94ac3-aa04-4d7f-92c7-30192811f166" />

Now when an error occurs, the terminal color is reset to default.
