### PR TITLE
Chore/create command parser service

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    
+        {
+            "name": "C#: Clarity.Dev.CLI",
+            "type": "dotnet",
+            "request": "launch",
+            "projectPath": "${workspaceFolder}\\Clarity.Dev\\src\\Clarity.Dev.CLI\\Clarity.Dev.CLI.csproj",
+            "launchConfigurationId": "TargetFramework=;Clarity.Dev.CLI"
+        }
+    ]
+}

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Clarity.Dev.NET.Analyzer.csproj
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Clarity.Dev.NET.Analyzer.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="QuestPDF" Version="2025.7.4" />
     <PackageReference Include="System.Composition" Version="10.0.0" />

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Contracts/ICommandParser.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Contracts/ICommandParser.cs
@@ -1,0 +1,8 @@
+﻿using Clarity.Dev.NET.Core.Models.Contracts;
+
+namespace Clarity.Dev.NET.Analyzer.Contracts;
+
+public interface ICommandParser
+{
+    IAnalysisCommand Parse(string[] args, IConfigurationRoot config);
+}

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Contracts/IConsoleService.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Contracts/IConsoleService.cs
@@ -3,6 +3,7 @@
 public interface IConsoleService
 {
     public void DisplayHeader(string version);
+    public void DisplayHelp();
     public void DisplayLineSeparator();
     public void DisplayNewLine();
     public void DisplayInfo(string message);

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/CommandParser.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/CommandParser.cs
@@ -1,0 +1,118 @@
+﻿using Clarity.Dev.NET.Core.Models.Contracts;
+
+namespace Clarity.Dev.NET.Analyzer.Core;
+
+public class CommandParser : ICommandParser
+{
+    public IAnalysisCommand Parse(string[] args, IConfigurationRoot config)
+    {
+        IAnalysisCommand command = new AnalysisCommand();
+
+        if (args.Length == 0)
+        {
+            ApplyDefaults(command, config);
+            return command;
+        }
+
+        // Pre-scan for help and version flags
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (SolutionCommandConstantsHelper.IsHelpOption(args[i]))
+            {
+                command.IsHelp = true;
+                return command;
+            }
+
+            if (SolutionCommandConstantsHelper.IsVersionOption(args[i]))
+            {
+                command.IsVersion = true;
+                return command;
+            }
+        }
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (i == 0 &&
+                !SolutionCommandConstantsHelper.IsOutputOption(args[i]) &&
+                !SolutionCommandConstantsHelper.IsOutputPathOption(args[i]) &&
+                !SolutionCommandConstantsHelper.IsPathOption(args[i]))
+            {
+                command.SolutionPath = args[0];
+            }
+            else if (SolutionCommandConstantsHelper.IsOutputOption(args[i]) && (i + 1) < args.Length)
+            {
+                if (!OutputFormatTypesHelper.IsValidOutputFormat(args[i + 1]))
+                {
+                    throw new Exception("Invalid Output Format!");
+                }
+                if (File.Exists(args[i + 1]))
+                {
+                    throw new Exception("Output file already exists!");
+                }
+                if (!string.IsNullOrEmpty(command.OutputFormat))
+                {
+                    // The output format has already been set, skip to avoid overwriting
+                    continue;
+                }
+                command.OutputFormat = args[i + 1];
+                i++;
+            }
+            else if (SolutionCommandConstantsHelper.IsOutputPathOption(args[i]) && (i + 1) < args.Length)
+            {
+                if (!string.IsNullOrEmpty(command.OutputPath))
+                {
+                    // The output path has already been set, skip to avoid overwriting
+                    continue;
+                }
+                command.OutputPath = args[i + 1];
+                i++;
+            }
+            else if (SolutionCommandConstantsHelper.IsPathOption(args[i]) && (i + 1) < args.Length)
+            {
+                if (!string.IsNullOrEmpty(command.SolutionPath))
+                {
+                    // The output path has already been set, skip to avoid overwriting
+                    continue;
+                }
+                command.SolutionPath = args[i + 1];
+                i++;
+            }
+            else
+            {
+                throw new Exception($"Unrecognized argument: {args[i]}");
+            }
+        }
+
+        ApplyDefaults(command, config);
+
+        return command;
+    }
+
+    private void ApplyDefaults(IAnalysisCommand command, IConfigurationRoot config)
+    {
+        // If the solution path is not provided, we can attempt to find a .sln file in the current directory
+        if (string.IsNullOrEmpty(command.SolutionPath))
+        {
+            // If we're on debug, we can look for the default solution path in the appsettings.json file, otherwise set the current directory as the solution path
+            #if DEBUG
+                command.SolutionPath = config.GetSection("DefaultTestProject").Value ?? GetDefaultSolutionPath();
+            #else
+                command.SolutionPath = GetDefaultSolutionPath();   
+            #endif
+        }
+        if (string.IsNullOrEmpty(command.OutputPath))
+        {
+            command.OutputPath = GetDefaultOutputPath();
+        }
+        if (string.IsNullOrEmpty(command.OutputFormat))
+        {
+            command.OutputFormat = GetDefaultOutputFormat();
+        }
+    }
+
+    private string GetDefaultSolutionPath() => Directory.GetCurrentDirectory();
+
+    private string GetDefaultOutputPath() => Path.Combine(Directory.GetCurrentDirectory(), "Clarity.Dev.Output");
+
+    private string GetDefaultOutputFormat() => OutputFormatTypes.html.ToString();
+}

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/ConsoleService.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/ConsoleService.cs
@@ -6,7 +6,7 @@ public class ConsoleService : IConsoleService
     {
         this.SetForegroundColor(ConsoleColor.Red);
         this.DisplayInfo($"   Error: {message}");
-        
+
         if (!string.IsNullOrEmpty(exceptionMessage))
         {
             this.DisplayInfo($"   Error: {exceptionMessage}");
@@ -37,6 +37,18 @@ public class ConsoleService : IConsoleService
         this.DisplayLineSeparator();
         this.DisplayInfo($"Version: {version}");
         this.DisplayNewLine();
+    }
+
+    public void DisplayHelp()
+    {
+        this.DisplayInfo("Usage: dotnet clarity-dev [options]");
+        this.DisplayNewLine();
+        this.DisplayInfo("Options:");
+        this.DisplayInfo("  --path <path>         Path to solution file or directory");
+        this.DisplayInfo("  --output <format>     Output format (e.g., html)");
+        this.DisplayInfo("  --output-path <path>  Output directory path");
+        this.DisplayInfo("  -help                 Display this help message");
+        this.DisplayInfo("  --version             Display version information");
     }
 
     public void DisplayInfo(string message)

--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/GlobalUsings.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/GlobalUsings.cs
@@ -7,7 +7,7 @@ global using System.Diagnostics;
 global using Clarity.Dev.NET.Core.Models;
 global using System.Xml.Linq;
 global using Microsoft.CodeAnalysis.CSharp.Syntax;
-global using Clarity.Dev.NET.Analyzer.Analysis;
 global using Clarity.Dev.NET.Analyzer.Contracts;
+global using Microsoft.Extensions.Configuration;
 
 namespace Clarity.Dev.NET.Analyzer;

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Clarity.Dev.CLI.csproj
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Clarity.Dev.CLI.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="18.0.2" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
   </ItemGroup>

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
@@ -21,22 +21,12 @@ try
     if (command.IsHelp)
     {
         consoleService.DisplayHeader(cliVersion);
-        Console.WriteLine("Usage: dotnet clarity-dev [options]");
-        Console.WriteLine();
-        Console.WriteLine("Options:");
-        Console.WriteLine("  --path <path>         Path to solution file or directory");
-        Console.WriteLine("  --output <format>     Output format (e.g., html)");
-        Console.WriteLine("  --output-path <path>  Output directory path");
-        Console.WriteLine("  -help                 Display this help message");
-        Console.WriteLine("  --version             Display version information");
-        return;
+        consoleService.DisplayHelp();
     }
-
-    consoleService.DisplayHeader(cliVersion);
 
     await SolutionAnalyzer.AnalyzeSolution(command, consoleService);
 }
-catch(Exception e)
+catch (Exception e)
 {
     Console.ForegroundColor = ConsoleColor.Red;
     Console.WriteLine(e.Message);

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
@@ -1,12 +1,40 @@
-﻿
+
 try
 {
     IConsoleService consoleService = new ConsoleService();
     var cliVersion = GetCliVersion();
-    consoleService.DisplayHeader("1.0.0-beta");
 
-    var solutionAnalysisInput = SolutionAnalyzer.GetOutputCommands(args);
-    await SolutionAnalyzer.AnalyzeSolution(solutionAnalysisInput, consoleService);
+    var config = new ConfigurationBuilder()
+        .SetBasePath(Directory.GetCurrentDirectory())
+        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+        .Build();
+
+    ICommandParser commandParser = new CommandParser();
+    var command = commandParser.Parse(args, config);
+
+    if (command.IsVersion)
+    {
+        Console.WriteLine($"Clarity.Dev CLI Version: {cliVersion}");
+        return;
+    }
+
+    if (command.IsHelp)
+    {
+        consoleService.DisplayHeader(cliVersion);
+        Console.WriteLine("Usage: dotnet clarity-dev [options]");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --path <path>         Path to solution file or directory");
+        Console.WriteLine("  --output <format>     Output format (e.g., html)");
+        Console.WriteLine("  --output-path <path>  Output directory path");
+        Console.WriteLine("  -help                 Display this help message");
+        Console.WriteLine("  --version             Display version information");
+        return;
+    }
+
+    consoleService.DisplayHeader(cliVersion);
+
+    await SolutionAnalyzer.AnalyzeSolution(command, consoleService);
 }
 catch(Exception e)
 {

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Properties/launchSettings.json
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Clarity.Dev.CLI": {
+      "commandName": "Project",
+      "commandLineArgs": "-help",
+      "dotnetRunMessages": true
+    }
+  }
+}

--- a/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs
@@ -1,16 +1,18 @@
-﻿namespace Clarity.Dev.CLI;
+using Clarity.Dev.NET.Core.Models.Contracts;
+
+namespace Clarity.Dev.CLI;
 
 internal static class SolutionAnalyzer
 {
-    public static async Task<int> AnalyzeSolution(SolutionAnalysisInput solutionAnalysisInput, IConsoleService consoleService)
+    public static async Task<int> AnalyzeSolution(IAnalysisCommand command, IConsoleService consoleService)
     {
         try
         {
 
-            if (!File.Exists(solutionAnalysisInput.SolutionPath))
+            if (!File.Exists(command.SolutionPath))
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                consoleService.DisplayInfo($"❌ Error: Solution file not found: {solutionAnalysisInput.SolutionPath}");
+                consoleService.DisplayInfo($"❌ Error: Solution file not found: {command.SolutionPath}");
                 Console.ResetColor();
                 return 1;
             }
@@ -21,7 +23,7 @@ internal static class SolutionAnalyzer
             CircularDependencyDetector _circularDependencyDetector = new();
             SlnxParser _slnxParser = new();
             var scanner = new SolutionScanner(_projectParser, _serviceDetector, _communicationAnalyzer, _circularDependencyDetector, _slnxParser, consoleService);
-            var result = await scanner.AnalyzeSolutionAsync(solutionAnalysisInput.SolutionPath);
+            var result = await scanner.AnalyzeSolutionAsync(command.SolutionPath);
 
             consoleService.DisplaySuccess("Analysis complete!");
             consoleService.DisplayInfo($"  - Projects: {result.Statistics.TotalProjects}");
@@ -36,13 +38,13 @@ internal static class SolutionAnalyzer
 
             consoleService.DisplayLineSeparator();
 
-            if(OutputFormatTypesHelper.IsHtmlFormat(solutionAnalysisInput.OutputFormat) ||
-                OutputFormatTypesHelper.IsBothFormat(solutionAnalysisInput.OutputFormat))
+            if(OutputFormatTypesHelper.IsHtmlFormat(command.OutputFormat) ||
+                OutputFormatTypesHelper.IsBothFormat(command.OutputFormat))
             {
                 HtmlReportGenerator htmlReportGenerator = new();
-                var htmlPath = solutionAnalysisInput.OutputPath.EndsWith(".html")
-                    ? solutionAnalysisInput.OutputPath
-                    : Path.ChangeExtension(solutionAnalysisInput.OutputPath, ".html");
+                var htmlPath = command.OutputPath.EndsWith(".html")
+                    ? command.OutputPath
+                    : Path.ChangeExtension(command.OutputPath, ".html");
                 var generatedHtmlPath = htmlReportGenerator.GenerateReport(result, htmlPath);
 
                 Console.ForegroundColor = ConsoleColor.Cyan;
@@ -59,92 +61,4 @@ internal static class SolutionAnalyzer
             throw;
         }
     }
-
-    public static SolutionAnalysisInput GetOutputCommands(string[] arguments)
-    {
-        SolutionAnalysisInput input = new();
-
-        for (int inputIndex = 0; inputIndex < arguments.Length; inputIndex++)
-        {
-            if (inputIndex == 0 &&
-                !SolutionCommandConstantsHelper.IsOutputOption(arguments[inputIndex]) &&
-                !SolutionCommandConstantsHelper.IsOutputPathOption(arguments[inputIndex]) &&
-                !SolutionCommandConstantsHelper.IsPathOption(arguments[inputIndex]))
-            {
-                input.SolutionPath = arguments[0];
-            }
-            else if (SolutionCommandConstantsHelper.IsOutputOption(arguments[inputIndex]) && (inputIndex + 1) <= arguments.Length)
-            {
-                if (!OutputFormatTypesHelper.IsValidOutputFormat(arguments[inputIndex + 1]))
-                {
-                    throw new Exception("Invalid Output Format!");
-                }
-                if(File.Exists(arguments[inputIndex + 1]))
-                {
-                    throw new Exception("Output file already exists!");
-                }
-                if (!string.IsNullOrEmpty(input.OutputFormat))
-                {
-                    // The output format has already been set, skip to avoid overwriting
-                    continue;
-                }
-                input.OutputFormat = arguments[inputIndex + 1];
-                inputIndex++;
-            }
-            else if (SolutionCommandConstantsHelper.IsOutputPathOption(arguments[inputIndex]) && (inputIndex + 1) <= arguments.Length)
-            {
-                if (!string.IsNullOrEmpty(input.OutputPath))
-                {
-                    // The output path has already been set, skip to avoid overwriting
-                    continue;
-                }
-                input.OutputPath = arguments[inputIndex + 1];
-                inputIndex++;
-            }
-            else if (SolutionCommandConstantsHelper.IsPathOption(arguments[inputIndex]) && (inputIndex + 1) <= arguments.Length)
-            {
-                if (!string.IsNullOrEmpty(input.SolutionPath))
-                {
-                    // The output path has already been set, skip to avoid overwriting
-                    continue;
-                }
-                input.SolutionPath = arguments[inputIndex + 1];
-                inputIndex++;
-            }
-            else
-            {
-                throw new Exception($"Unrecognized argument: {arguments[inputIndex]}");
-            }
-        }
-
-        // If the solution path is not provided, we can attempt to find a .sln file in the current directory
-        if (string.IsNullOrEmpty(input.SolutionPath))
-        {
-            // If we're on debug, we can look for the default solution path in the appsettings.json file, otherwise set the current directory as the solution path
-            #if DEBUG
-                var config = new ConfigurationBuilder()
-                        .SetBasePath(Directory.GetCurrentDirectory())
-                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                        .Build();
-                input.SolutionPath = config.GetSection("DefaultTestProject").Value ?? GetDefaultSolutionPath();
-            #else
-                input.SolutionPath = GetDefaultSolutionPath();   
-            #endif
-        }
-        if (string.IsNullOrEmpty(input.OutputPath))
-        {
-            input.OutputPath = GetDefaultOutputPath();
-        }
-        if (string.IsNullOrEmpty(input.OutputFormat))
-        {
-            input.OutputFormat = GetDefaultOutputFormat();
-        }
-        return input;
-    }
-
-    private static string GetDefaultSolutionPath() => Directory.GetCurrentDirectory();
-
-    private static string GetDefaultOutputPath() => Path.Combine(Directory.GetCurrentDirectory(), "Clarity.Dev.Output");
-
-    private static string GetDefaultOutputFormat() => OutputFormatTypes.html.ToString();
 }

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/GlobalUsings.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/GlobalUsings.cs
@@ -1,7 +1,5 @@
 ﻿global using System;
 global using System.Collections.Generic;
-global using System.Text;
-global using Clarity.Dev.NET.Core.Models;
 global using Clarity.Dev.NET.Core.Models.Enums;
 
 namespace Clarity.Dev.NET.Core;

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/AnalysisCommand.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/AnalysisCommand.cs
@@ -1,0 +1,12 @@
+using Clarity.Dev.NET.Core.Models.Contracts;
+
+namespace Clarity.Dev.NET.Core.Models;
+
+public class AnalysisCommand : IAnalysisCommand
+{
+    public string SolutionPath { get; set; } = string.Empty;
+    public string OutputFormat { get; set; } = string.Empty;
+    public string OutputPath { get; set; } = string.Empty;
+    public bool IsHelp { get; set; }
+    public bool IsVersion { get; set; }
+}

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/Contracts/IAnalysisCommand.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/Contracts/IAnalysisCommand.cs
@@ -1,0 +1,10 @@
+namespace Clarity.Dev.NET.Core.Models.Contracts;
+
+public interface IAnalysisCommand
+{
+    string SolutionPath { get; set; }
+    string OutputFormat { get; set; }
+    string OutputPath { get; set; }
+    bool IsHelp { get; set; }
+    bool IsVersion { get; set; }
+}

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionAnalysisInput.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionAnalysisInput.cs
@@ -1,8 +1,0 @@
-﻿namespace Clarity.Dev.NET.Core.Models;
-
-public class SolutionAnalysisInput
-{
-    public string SolutionPath { get; set; }
-    public string OutputFormat { get; set; }
-    public string OutputPath { get; set; }
-}

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstants.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstants.cs
@@ -1,7 +1,7 @@
-﻿namespace Clarity.Dev.NET.Core.Models;
+namespace Clarity.Dev.NET.Core.Models;
 
 /// <summary>
-/// Constants for solution command options
+/// Constants for solution command options 🦢
 /// </summary>
 public static class SolutionCommandConstants
 {
@@ -24,4 +24,9 @@ public static class SolutionCommandConstants
     /// Represents the command-line option to display help information.
     /// </summary>
     public const string HelpOption = "-help";
+
+    /// <summary>
+    /// Represents the command-line option to display version information.
+    /// </summary>
+    public const string VersionOption = "--version";
 }

--- a/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstantsHelper.cs
+++ b/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstantsHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace Clarity.Dev.NET.Core.Models;
+namespace Clarity.Dev.NET.Core.Models;
 
 /// <summary>
 /// Provides static helper methods for determining whether a specified argument matches predefined command-line options
@@ -49,4 +49,15 @@ public static class SolutionCommandConstantsHelper
     /// <see langword="true"/> if the argument matches the help option; otherwise, <see langword="false"/>.
     /// </returns>
     public static bool IsHelpOption(string arg) => arg.Equals(SolutionCommandConstants.HelpOption, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether the specified argument matches the predefined version option, ignoring case.
+    /// </summary>
+    /// <param name="arg">
+    /// This string is compared to the constant value defined in <see cref="SolutionCommandConstants.VersionOption"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the argument matches the version option; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool IsVersionOption(string arg) => arg.Equals(SolutionCommandConstants.VersionOption, StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
# Abstract command parsing from SolutionAnalyzer.GetOutputCommands()

### Summary
This PR refactors the command-line argument parsing logic to cleanly abstract it out of [SolutionAnalyzer](cci:2://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs:4:0-63:1), adhering to a cleaner separation of concerns. It introduces a dedicated `CommandParser` along with a robust `IAnalysisCommand` model to replacing `SolutionAnalysisInput`. 

### Key Changes
- **Extracted Parsing Logic:** Removed `GetOutputCommands()` from [SolutionAnalyzer](cci:2://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.CLI/SolutionAnalyzer.cs:4:0-63:1) and migrated it to a dedicated `CommandParser` class implementing `ICommandParser`.
- **Command Models:** Replaced `SolutionAnalysisInput` with `IAnalysisCommand` and [AnalysisCommand](cci:2://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/AnalysisCommand.cs:4:0-11:1) to strongly type the parsed options.
- **Help/Version Support:** Added full support for early exits using the `-help` and `--version` arguments directly in [Program.cs](cci:7://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs:0:0-0:0) before initiating solution analysis.
- **Constants Updates:** Added `--version` to predefined arguments in [SolutionCommandConstants](cci:2://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstants.cs:5:0-31:1) and mapping logic to [SolutionCommandConstantsHelper](cci:2://file:///c:/Users/sphesihle.jamile/Videos/.NET/Clarity.Dev/src/Clarity.Dev.NET.Core/Models/SolutionCommandConstantsHelper.cs:6:0-62:1).

### Validation
- Existing command formats (`dotnet clarity-dev <path>`, `dotnet clarity-dev --path <path>`, `dotnet clarity-dev --output html`) have been manually verified to behave exactly as before.
