### PR TITLE
Chore/service collection exctensions

### DIFF
--- a/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/SolutionScanner.cs
+++ b/Clarity.Dev/src/Clarity.Dev.Analyzer/Core/SolutionScanner.cs
@@ -1,4 +1,4 @@
-﻿namespace Clarity.Dev.NET.Analyzer.Core;
+namespace Clarity.Dev.NET.Analyzer.Core;
 
 /// <summary>
 /// Main orchestrator for analyzing .NET solutions 🦢
@@ -40,6 +40,7 @@ public class SolutionScanner(
         _consoleService.DisplayInfo($"Analyzing Solution: {result.SolutionName}");
 
         // Step 1: Detect solution file type and load projects accordingly
+        cancellationToken.ThrowIfCancellationRequested();
         var extension = Path.GetExtension(solutionPath).ToLowerInvariant();
         AdhocWorkspace workspace;
         AnalyzerManager? manager = null;
@@ -65,6 +66,7 @@ public class SolutionScanner(
         _consoleService.DisplayInfo($"Found {workspace.CurrentSolution.Projects.Count()} projects");
 
         // Step 2: Parse and analyze each project in solution in parallel
+        cancellationToken.ThrowIfCancellationRequested();
         var projectTasks = workspace.CurrentSolution.Projects
             .Select(async project =>
             {
@@ -87,6 +89,7 @@ public class SolutionScanner(
         _consoleService.DisplayInfo($"Successfully parsed {result.Projects.Count} projects!");
 
         // Step 3: Detect services in each project
+        cancellationToken.ThrowIfCancellationRequested();
         foreach(var projectInfo in result.Projects)
         {
             var roslynProject = workspace.CurrentSolution.Projects.FirstOrDefault(proj => proj.Name == projectInfo.Name);
@@ -101,12 +104,14 @@ public class SolutionScanner(
         _consoleService.DisplayInfo($"Detected {result.Projects.Sum(p => p.DetectedServices.Count)} services");
 
         // Step 4: Analyze service communication
+        cancellationToken.ThrowIfCancellationRequested();
         result.ServiceCommunications = await _communicationAnalyzer.AnalyzeCommunicationAsync(
             workspace.CurrentSolution,
             result.Projects,
             cancellationToken);
 
         // Step 5: Detect circular dependencies
+        cancellationToken.ThrowIfCancellationRequested();
         result.CircularDependencies = _circularDependencyDetector.DetectCircularDependencies(result.Projects);
 
         if (result.CircularDependencies.Any())

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Extensions/ServiceCollectionExtensions.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using Clarity.Dev.CLI.Contracts;
+using Clarity.Dev.CLI.Services;
+using Clarity.Dev.Reports.Contracts;
+
+namespace Clarity.Dev.CLI.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all Clarity.Dev CLI services into the DI container.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <param name="configuration">Optional configuration root. If not provided, one will be built from appsettings.json.</param>
+    public static IServiceCollection AddClarityCli(
+        this IServiceCollection services,
+        IConfigurationRoot? configuration = null)
+    {
+        // Build configuration if not externally provided
+        var config = configuration ?? new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .Build();
+
+        // Configuration — Singleton: shared, immutable for the lifetime of the app
+        services.AddSingleton<IConfigurationRoot>(config);
+        services.AddSingleton<IConfiguration>(config);
+
+        // CLI services — Singleton: stateless, safe to reuse across operations
+        services.AddSingleton<IConsoleService, ConsoleService>();
+        services.AddSingleton<ICommandParser, CommandParser>();
+        services.AddSingleton<IVersionProvider, VersionProvider>();
+
+        // Report generator — Singleton: stateless, produces output from data
+        services.AddSingleton<IHtmlReportGenerator, HtmlReportGenerator>();
+
+        // Analyzer components — Transient: each scan is a fresh operation
+        services.AddTransient<IProjectParser, ProjectParser>();
+        services.AddTransient<IServiceDetector, ServiceDetector>();
+        services.AddTransient<ISlnxParser, SlnxParser>();
+        services.AddTransient<ICommunicationAnalyzer, CommunicationAnalyzer>();
+        services.AddTransient<ICircularDependencyDetector, CircularDependencyDetector>();
+        services.AddTransient<ISolutionScanner, SolutionScanner>();
+        services.AddTransient<ISolutionAnalyzer, SolutionAnalyzer>();
+
+        // Application entry point — Transient: resolves fresh per invocation
+        services.AddTransient<IApplicationService, ApplicationService>();
+
+        return services;
+    }
+}

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Program.cs
@@ -1,31 +1,17 @@
 using Microsoft.Extensions.DependencyInjection;
 using Clarity.Dev.CLI.Contracts;
-using Clarity.Dev.CLI.Services;
-using Clarity.Dev.Reports.Contracts;
-
-var config = new ConfigurationBuilder()
-    .SetBasePath(Directory.GetCurrentDirectory())
-    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-    .Build();
+using Clarity.Dev.CLI.Extensions;
 
 var serviceProvider = new ServiceCollection()
-    .AddSingleton<IConfigurationRoot>(config)
-    .AddSingleton<IConfiguration>(config)
-    .AddTransient<IConsoleService, ConsoleService>()
-    .AddTransient<ICommandParser, CommandParser>()
-    .AddTransient<IVersionProvider, VersionProvider>()
-    .AddTransient<IApplicationService, ApplicationService>()
-    .AddTransient<ISolutionAnalyzer, SolutionAnalyzer>()
-    
-    .AddTransient<IProjectParser, ProjectParser>()
-    .AddTransient<IServiceDetector, ServiceDetector>()
-    .AddTransient<ISlnxParser, SlnxParser>()
-    .AddTransient<ICommunicationAnalyzer, CommunicationAnalyzer>()
-    .AddTransient<ICircularDependencyDetector, CircularDependencyDetector>()
-    .AddTransient<ISolutionScanner, SolutionScanner>()
-
-    .AddSingleton<IHtmlReportGenerator, HtmlReportGenerator>()
+    .AddClarityCli()
     .BuildServiceProvider();
 
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+
 var app = serviceProvider.GetRequiredService<IApplicationService>();
-return await app.RunAsync(args);
+return await app.RunAsync(args, cts.Token);

--- a/Clarity.Dev/src/Clarity.Dev.CLI/Services/SolutionAnalyzer.cs
+++ b/Clarity.Dev/src/Clarity.Dev.CLI/Services/SolutionAnalyzer.cs
@@ -38,8 +38,9 @@ public class SolutionAnalyzer : ISolutionAnalyzer
 
             consoleService.DisplayLineSeparator();
 
-            if(OutputFormatTypesHelper.IsHtmlFormat(command.OutputFormat) ||
-                OutputFormatTypesHelper.IsBothFormat(command.OutputFormat))
+            if((OutputFormatTypesHelper.IsHtmlFormat(command.OutputFormat) ||
+                OutputFormatTypesHelper.IsBothFormat(command.OutputFormat)) &&
+                cancellationToken.IsCancellationRequested == false)
             {
                 var htmlPath = command.OutputPath.EndsWith(".html")
                     ? command.OutputPath
@@ -56,7 +57,7 @@ public class SolutionAnalyzer : ISolutionAnalyzer
         }
         catch (OperationCanceledException)
         {
-            consoleService.DisplayWarning("⚠️ Analysis was cancelled.");
+            consoleService.DisplayWarning("    Analysis was cancelled.");
             return 1;
         }
         catch (Exception ex)


### PR DESCRIPTION
Introduced ServiceCollectionExtensions.AddClarityCli() to consolidate all DI registrations into a single extension method with appropriate service lifetimes. Reduced Program.cs to a clean composition root with Ctrl+C cancellation support via CancellationTokenSource. Fixed a cancellation bug in SolutionScanner by adding ThrowIfCancellationRequested() checkpoints between each analysis step, ensuring the process exits promptly instead of running to completion.